### PR TITLE
fix size computation for allocation may overflow

### DIFF
--- a/network/p2p/client.go
+++ b/network/p2p/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/DioneProtocol/odysseygo/ids"
 	"github.com/DioneProtocol/odysseygo/snow/engine/common"
@@ -175,8 +176,13 @@ func (c *Client) CrossChainAppRequest(
 // Response messages don't need to be prefixed because request ids are tracked
 // which map to the expected response handler.
 func (c *Client) prefixMessage(src []byte) []byte {
-	messageBytes := make([]byte, len(c.handlerPrefix)+len(src))
+	handlerPrefixLen := len(c.handlerPrefix)
+	srcLen := len(src)
+	if srcLen > math.MaxInt-handlerPrefixLen {
+		panic(fmt.Sprintf("prefixMessage: message too large: handlerPrefixLen=%d, srcLen=%d", handlerPrefixLen, srcLen))
+	}
+	messageBytes := make([]byte, handlerPrefixLen+srcLen)
 	copy(messageBytes, c.handlerPrefix)
-	copy(messageBytes[len(c.handlerPrefix):], src)
+	copy(messageBytes[handlerPrefixLen:], src)
 	return messageBytes
 }


### PR DESCRIPTION
https://github.com/DioneProtocol/odysseygo/blob/3fb948026bea0b7834ee336a5622e986e4242a68/network/p2p/client.go#L178-L178

https://github.com/DioneProtocol/odysseygo/blob/3fb948026bea0b7834ee336a5622e986e4242a68/network/p2p/client.go#L180-L180

Performing calculations involving the size of potentially large strings or slices can result in an overflow (for signed integer types) or a wraparound (for unsigned types). An overflow causes the result of the calculation to become negative, while a wraparound results in a small (positive) number. This can cause further issues. If, for example, the result is then used in an allocation, it will cause a runtime panic if it is negative, and allocate an unexpectedly small buffer otherwise.



fix this problem, we need to ensure that the sum `len(c.handlerPrefix) + len(src)` cannot overflow the `int` type used by Go's `make` function. The best way to do this is to check that `len(src)` is not so large that adding it to `len(c.handlerPrefix)` would exceed `math.MaxInt` (the maximum value of an `int`). If it would, we should return a nil or error value, or otherwise handle the case gracefully. Since `prefixMessage` is a private method and always called in the context of sending a message, the most compatible fix is to panic or return an empty slice if the size is too large, but ideally, we should propagate an error. However, to avoid changing the function signature, we can return `nil` or panic with a clear error message.

We will:
- Import the `math` package to access `math.MaxInt`.
- Add a check in `prefixMessage` to ensure that `len(src)` does not cause an overflow when added to `len(c.handlerPrefix)`.
- If the check fails, we panic with a clear error message (alternatively, we could return `nil`, but panic is more explicit and consistent with Go's handling of allocation errors).


#### References
[Integer overflow](https://golang.org/ref/spec#Integer_overflow)
[Making slices, maps and channels](https://golang.org/ref/spec#Making_slices_maps_and_channels)
[CWE-190](https://cwe.mitre.org/data/definitions/190.html)