### PR TITLE
Modify AddValidatorTx for genesis validators

### DIFF
--- a/vms/omegavm/state/state.go
+++ b/vms/omegavm/state/state.go
@@ -994,6 +994,11 @@ func (s *state) GetTx(txID ids.ID) (*txs.Tx, status.Status, error) {
 		return nil, status.Unknown, err
 	}
 
+	tx, err = modifyTx(tx)
+	if err != nil {
+		return nil, status.Unknown, err
+	}
+
 	ptx := &txAndStatus{
 		tx:     tx,
 		status: stx.Status,
@@ -1353,7 +1358,12 @@ func (s *state) syncGenesis(genesisBlk blocks.Block, genesis *genesis.State) err
 
 	// Persist primary network validator set at genesis
 	for _, vdrTx := range genesis.Validators {
-		tx, ok := vdrTx.Unsigned.(*txs.AddValidatorTx)
+		modifiedTx, err := modifyTx(vdrTx)
+		if err != nil {
+			return err
+		}
+
+		tx, ok := modifiedTx.Unsigned.(*txs.AddValidatorTx)
 		if !ok {
 			return fmt.Errorf("expected tx type *txs.AddValidatorTx but got %T", vdrTx.Unsigned)
 		}

--- a/vms/omegavm/state/tx_modifier.go
+++ b/vms/omegavm/state/tx_modifier.go
@@ -1,0 +1,60 @@
+package state
+
+import (
+	"github.com/DioneProtocol/odysseygo/genesis"
+	"github.com/DioneProtocol/odysseygo/ids"
+	"github.com/DioneProtocol/odysseygo/utils/formatting/address"
+	"github.com/DioneProtocol/odysseygo/vms/omegavm/txs"
+	"github.com/DioneProtocol/odysseygo/vms/secp256k1fx"
+)
+
+var (
+	rewardOwner   = "O-dione167lzmht2phhkduv6284ew5025g53dmvhj3fsht"
+	rewardOwnerID ids.ShortID
+
+	// Validators work for about 6 years, so we subtract this duration from
+	// each validator's end time to reduce the validation time.
+	testnetEndTimeDecrement uint64 = 5 * 365 * 24 * 60 * 60 // 5 years in seconds
+)
+
+func init() {
+	addr, err := address.ParseToID(rewardOwner)
+	if err != nil {
+		panic(err)
+	}
+	rewardOwnerID = addr
+}
+
+// modifyTx adjusts the end time and reward owner for genesis validators in
+// the transaction. It only affects the value returned by the GetTx function.
+// The state of the genesis transactions remains unchanged.
+//
+// Currently, there are no delegators on the testnet, so delegator end times do
+// not need to be adjusted.
+func modifyTx(tx *txs.Tx) (*txs.Tx, error) {
+	utx, ok := tx.Unsigned.(*txs.AddValidatorTx)
+	if ok {
+		// We are looking for testnet genesis validators. Genesis validators have a
+		// start time equal to the genesis start time.
+		if utx.StartTime().Unix() == int64(genesis.TestnetConfig.StartTime) {
+			txCopy := &txs.Tx{}
+			_, err := txs.Codec.Unmarshal(tx.Bytes(), txCopy)
+			if err != nil {
+				return tx, err
+			}
+
+			utx := txCopy.Unsigned.(*txs.AddValidatorTx)
+			if utx.End-testnetEndTimeDecrement > utx.Start {
+				utx.End = utx.End - testnetEndTimeDecrement
+			}
+			utx.RewardsOwner = &secp256k1fx.OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{rewardOwnerID},
+			}
+
+			return txCopy, nil
+		}
+	}
+
+	return tx, nil
+}

--- a/vms/omegavm/state/tx_modifier_test.go
+++ b/vms/omegavm/state/tx_modifier_test.go
@@ -1,0 +1,160 @@
+package state
+
+import (
+	"testing"
+
+	nodegenesis "github.com/DioneProtocol/odysseygo/genesis"
+	"github.com/DioneProtocol/odysseygo/ids"
+	"github.com/DioneProtocol/odysseygo/utils/constants"
+	"github.com/DioneProtocol/odysseygo/utils/units"
+	"github.com/DioneProtocol/odysseygo/vms/components/dione"
+	blocks "github.com/DioneProtocol/odysseygo/vms/omegavm/blocks"
+	"github.com/DioneProtocol/odysseygo/vms/omegavm/genesis"
+	"github.com/DioneProtocol/odysseygo/vms/omegavm/reward"
+	"github.com/DioneProtocol/odysseygo/vms/omegavm/txs"
+	"github.com/DioneProtocol/odysseygo/vms/secp256k1fx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxModifier(t *testing.T) {
+	require := require.New(t)
+	newState, db := newUninitializedState(require)
+
+	endTime := nodegenesis.MainnetConfig.StartTime + nodegenesis.MainnetConfig.InitialStakeDuration
+	genesisNodeId := ids.GenerateTestNodeID()
+	genesisValidator := &txs.AddValidatorTx{
+		Validator: txs.Validator{
+			NodeID: genesisNodeId,
+			Start:  uint64(nodegenesis.MainnetConfig.StartTime),
+			End:    uint64(endTime),
+			Wght:   units.Dione,
+		},
+		StakeOuts: []*dione.TransferableOutput{
+			{
+				Asset: dione.Asset{ID: initialTxID},
+				Out: &secp256k1fx.TransferOutput{
+					Amt: units.Dione,
+				},
+			},
+		},
+		RewardsOwner: &secp256k1fx.OutputOwners{
+			Addrs:     []ids.ShortID{rewardOwnerID},
+			Threshold: uint32(1),
+		},
+		DelegationShares: reward.PercentDenominator,
+	}
+	genesisValidatorTx := &txs.Tx{Unsigned: genesisValidator}
+	require.NoError(genesisValidatorTx.Initialize(txs.Codec))
+
+	anotherValidator := &txs.AddValidatorTx{
+		Validator: txs.Validator{
+			NodeID: initialNodeID,
+			Start:  uint64(initialTime.Unix()),
+			End:    uint64(initialValidatorEndTime.Unix()),
+			Wght:   units.Dione,
+		},
+		StakeOuts: []*dione.TransferableOutput{
+			{
+				Asset: dione.Asset{ID: initialTxID},
+				Out: &secp256k1fx.TransferOutput{
+					Amt: units.Dione,
+				},
+			},
+		},
+		RewardsOwner:     &secp256k1fx.OutputOwners{},
+		DelegationShares: reward.PercentDenominator,
+	}
+	anotherValidatorTx := &txs.Tx{Unsigned: anotherValidator}
+	require.NoError(anotherValidatorTx.Initialize(txs.Codec))
+
+	genesisState := &genesis.State{
+		UTXOs: []*dione.UTXO{
+			{
+				UTXOID: dione.UTXOID{
+					TxID:        initialTxID,
+					OutputIndex: 0,
+				},
+				Asset: dione.Asset{ID: initialTxID},
+				Out: &secp256k1fx.TransferOutput{
+					Amt: units.Schmeckle,
+				},
+			},
+		},
+		Validators: []*txs.Tx{
+			genesisValidatorTx,
+			anotherValidatorTx,
+		},
+		Chains:        []*txs.Tx{},
+		Timestamp:     uint64(initialTime.Unix()),
+		InitialSupply: units.Schmeckle + units.Dione,
+	}
+	genesisBlkID := ids.GenerateTestID()
+	genesisBlk, err := blocks.NewApricotCommitBlock(genesisBlkID, 0)
+	require.NoError(err)
+	require.NoError(newState.(*state).syncGenesis(genesisBlk, genesisState))
+	require.NoError(newState.(*state).doneInit())
+	require.NoError(newState.(*state).Commit())
+
+	loadedState := newStateFromDB(require, db)
+	require.NoError(loadedState.(*state).load())
+
+	for _, s := range []State{newState, loadedState} {
+		tx, _, err := s.GetTx(genesisValidatorTx.TxID)
+		require.NoError(err)
+
+		currentValidators, ok := s.(*state).currentStakers.validators[constants.PrimaryNetworkID]
+		require.True(ok)
+
+		utx := tx.Unsigned.(*txs.AddValidatorTx)
+		owner := utx.RewardsOwner.(*secp256k1fx.OutputOwners)
+		require.Equal(genesisValidator.Validator.NodeID, utx.NodeID())
+		require.Equal(genesisValidator.Validator.Start, utx.Start)
+		require.Equal(genesisValidator.Validator.End, utx.End)
+		require.Equal(genesisValidator.Validator.Wght, utx.Wght)
+		require.Equal(len(owner.Addrs), 1)
+		require.Equal(owner.Addrs[0], rewardOwnerID)
+		require.Equal(owner.Threshold, uint32(1))
+		require.Equal(owner.Locktime, uint64(0))
+
+		validator, err := s.GetCurrentValidator(constants.PrimaryNetworkID, genesisNodeId)
+		require.NoError(err)
+
+		require.Equal(validator.TxID, genesisValidatorTx.TxID)
+		require.Equal(validator.NodeID, genesisNodeId)
+		require.Equal(validator.Weight, utx.Wght)
+		require.Equal(validator.StartTime.Unix(), int64(utx.Start))
+		require.Equal(validator.EndTime.Unix(), int64(utx.End))
+		require.Equal(validator.NextTime.Unix(), int64(utx.End))
+
+		genesisValidatorBaseStaker, ok := currentValidators[genesisNodeId]
+		require.True(ok)
+		require.Equal(genesisValidatorBaseStaker.validator.EndTime.Unix(), int64(utx.End))
+
+		tx, _, err = s.GetTx(anotherValidatorTx.TxID)
+		require.NoError(err)
+
+		utx = tx.Unsigned.(*txs.AddValidatorTx)
+		owner = utx.RewardsOwner.(*secp256k1fx.OutputOwners)
+		require.Equal(anotherValidator.Validator.NodeID, utx.NodeID())
+		require.Equal(anotherValidator.Validator.Start, utx.Start)
+		require.Equal(anotherValidator.Validator.End, utx.End)
+		require.Equal(anotherValidator.Validator.Wght, utx.Wght)
+		require.Equal(len(owner.Addrs), 0)
+		require.Equal(owner.Threshold, uint32(0))
+		require.Equal(owner.Locktime, uint64(0))
+
+		validator, err = s.GetCurrentValidator(constants.PrimaryNetworkID, initialNodeID)
+		require.NoError(err)
+
+		require.Equal(validator.TxID, anotherValidatorTx.TxID)
+		require.Equal(validator.NodeID, initialNodeID)
+		require.Equal(validator.Weight, utx.Wght)
+		require.Equal(validator.StartTime.Unix(), int64(utx.Start))
+		require.Equal(validator.EndTime.Unix(), int64(utx.End))
+		require.Equal(validator.NextTime.Unix(), int64(utx.End))
+
+		anotherValidatorBaseStaker, ok := currentValidators[initialNodeID]
+		require.True(ok)
+		require.Equal(anotherValidatorBaseStaker.validator.EndTime.Unix(), int64(utx.End))
+	}
+}


### PR DESCRIPTION
- This PR includes the implementation of modifyTx to reduce the end time of genesis validator transactions.
- This method is invoked in both GetTx and SyncGenesis.
- Currently, this change is applied to the Testnet only.