### PR TITLE
Update delegator and inactive validator end time

### DIFF
--- a/vms/omegavm/blocks/builder/builder.go
+++ b/vms/omegavm/blocks/builder/builder.go
@@ -449,9 +449,6 @@ func getNextStakerToReward(
 		return ids.Empty, false, ErrEndOfTime
 	}
 
-	// Todo
-	preferredState.ModifyCurrentStakerIterator()
-
 	currentStakerIterator, err := preferredState.GetCurrentStakerIterator()
 	if err != nil {
 		return ids.Empty, false, err

--- a/vms/omegavm/blocks/builder/builder.go
+++ b/vms/omegavm/blocks/builder/builder.go
@@ -449,6 +449,9 @@ func getNextStakerToReward(
 		return ids.Empty, false, ErrEndOfTime
 	}
 
+	// Todo
+	preferredState.ModifyCurrentStakerIterator()
+
 	currentStakerIterator, err := preferredState.GetCurrentStakerIterator()
 	if err != nil {
 		return ids.Empty, false, err

--- a/vms/omegavm/state/diff.go
+++ b/vms/omegavm/state/diff.go
@@ -274,6 +274,18 @@ func (d *diff) GetCurrentStakerIterator() (StakerIterator, error) {
 	return d.currentStakerDiffs.GetStakerIterator(parentIterator), nil
 }
 
+func (d *diff) ModifyCurrentStakerIterator() (StakerIterator, error) {
+	parentState, ok := d.stateVersions.GetState(d.parentID)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
+	}
+	parentIterator, err := parentState.ModifyCurrentStakerIterator()
+	if err != nil {
+		return nil, err
+	}
+	return d.currentStakerDiffs.GetStakerIterator(parentIterator), nil
+}
+
 func (d *diff) GetCurrentStakersLen() (uint64, error) {
 	parentState, ok := d.stateVersions.GetState(d.parentID)
 	if !ok {

--- a/vms/omegavm/state/mock_chain.go
+++ b/vms/omegavm/state/mock_chain.go
@@ -247,6 +247,21 @@ func (mr *MockChainMockRecorder) GetCurrentStakerIterator() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentStakerIterator", reflect.TypeOf((*MockChain)(nil).GetCurrentStakerIterator))
 }
 
+// ModifyCurrentStakerIterator mocks base method.
+func (m *MockChain) ModifyCurrentStakerIterator() (StakerIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyCurrentStakerIterator")
+	ret0, _ := ret[0].(StakerIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyCurrentStakerIterator indicates an expected call of ModifyCurrentStakerIterator.
+func (mr *MockChainMockRecorder) ModifyCurrentStakerIterator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCurrentStakerIterator", reflect.TypeOf((*MockChain)(nil).ModifyCurrentStakerIterator))
+}
+
 // GetCurrentStakersLen mocks base method.
 func (m *MockChain) GetCurrentStakersLen() (uint64, error) {
 	m.ctrl.T.Helper()

--- a/vms/omegavm/state/mock_diff.go
+++ b/vms/omegavm/state/mock_diff.go
@@ -261,6 +261,21 @@ func (mr *MockDiffMockRecorder) GetCurrentStakerIterator() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentStakerIterator", reflect.TypeOf((*MockDiff)(nil).GetCurrentStakerIterator))
 }
 
+// ModifyCurrentStakerIterator mocks base method.
+func (m *MockDiff) ModifyCurrentStakerIterator() (StakerIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyCurrentStakerIterator")
+	ret0, _ := ret[0].(StakerIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyCurrentStakerIterator indicates an expected call of ModifyCurrentStakerIterator.
+func (mr *MockDiffMockRecorder) ModifyCurrentStakerIterator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCurrentStakerIterator", reflect.TypeOf((*MockDiff)(nil).ModifyCurrentStakerIterator))
+}
+
 // GetCurrentStakersLen mocks base method.
 func (m *MockDiff) GetCurrentStakersLen() (uint64, error) {
 	m.ctrl.T.Helper()

--- a/vms/omegavm/state/mock_state.go
+++ b/vms/omegavm/state/mock_state.go
@@ -377,6 +377,21 @@ func (mr *MockStateMockRecorder) GetCurrentStakerIterator() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentStakerIterator", reflect.TypeOf((*MockState)(nil).GetCurrentStakerIterator))
 }
 
+// ModifyCurrentStakerIterator mocks base method.
+func (m *MockState) ModifyCurrentStakerIterator() (StakerIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyCurrentStakerIterator")
+	ret0, _ := ret[0].(StakerIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyCurrentStakerIterator indicates an expected call of ModifyCurrentStakerIterator.
+func (mr *MockStateMockRecorder) ModifyCurrentStakerIterator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCurrentStakerIterator", reflect.TypeOf((*MockState)(nil).ModifyCurrentStakerIterator))
+}
+
 // GetCurrentStakersLen mocks base method.
 func (m *MockState) GetCurrentStakersLen() (uint64, error) {
 	m.ctrl.T.Helper()

--- a/vms/omegavm/state/stakers.go
+++ b/vms/omegavm/state/stakers.go
@@ -229,13 +229,17 @@ func (v *baseStakers) PutModifiedDelegator(staker *Staker) {
 	}
 	validator.delegators.ReplaceOrInsert(staker)
 
-	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
-	if validatorDiff.addedDelegators == nil {
-		validatorDiff.addedDelegators = btree.NewG(defaultTreeDegree, (*Staker).Less)
-	}
-	validatorDiff.addedDelegators.ReplaceOrInsert(staker)
-
 	v.stakers.ReplaceOrInsert(staker)
+}
+
+func (v *baseStakers) DeleteModifiedDelegator(staker *Staker) {
+	validator := v.getOrCreateValidator(staker.SubnetID, staker.NodeID)
+	if validator.delegators != nil {
+		validator.delegators.Delete(staker)
+	}
+	v.pruneValidator(staker.SubnetID, staker.NodeID)
+
+	v.stakers.Delete(staker)
 }
 
 func (v *baseStakers) DeleteDelegator(staker *Staker) {

--- a/vms/omegavm/state/stakers.go
+++ b/vms/omegavm/state/stakers.go
@@ -66,6 +66,8 @@ type CurrentStakers interface {
 	// the current staker set.
 	GetCurrentStakerIterator() (StakerIterator, error)
 
+	ModifyCurrentStakerIterator() (StakerIterator, error)
+
 	// GetCurrentStakersLen returns current stakers amount
 	GetCurrentStakersLen() (uint64, error)
 }
@@ -169,6 +171,17 @@ func (v *baseStakers) PutValidator(staker *Staker) {
 	v.stakers.ReplaceOrInsert(staker)
 }
 
+func (v *baseStakers) PutModifiedValidator(staker *Staker) {
+	validator := v.getOrCreateValidator(staker.SubnetID, staker.NodeID)
+	validator.validator = staker
+
+	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
+	validatorDiff.validator = staker
+	validatorDiff.validatorStatus = unmodified
+
+	v.stakers.ReplaceOrInsert(staker)
+}
+
 func (v *baseStakers) DeleteValidator(staker *Staker) {
 	validator := v.getOrCreateValidator(staker.SubnetID, staker.NodeID)
 	validator.validator = nil
@@ -194,6 +207,22 @@ func (v *baseStakers) GetDelegatorIterator(subnetID ids.ID, nodeID ids.NodeID) S
 }
 
 func (v *baseStakers) PutDelegator(staker *Staker) {
+	validator := v.getOrCreateValidator(staker.SubnetID, staker.NodeID)
+	if validator.delegators == nil {
+		validator.delegators = btree.NewG(defaultTreeDegree, (*Staker).Less)
+	}
+	validator.delegators.ReplaceOrInsert(staker)
+
+	validatorDiff := v.getOrCreateValidatorDiff(staker.SubnetID, staker.NodeID)
+	if validatorDiff.addedDelegators == nil {
+		validatorDiff.addedDelegators = btree.NewG(defaultTreeDegree, (*Staker).Less)
+	}
+	validatorDiff.addedDelegators.ReplaceOrInsert(staker)
+
+	v.stakers.ReplaceOrInsert(staker)
+}
+
+func (v *baseStakers) PutModifiedDelegator(staker *Staker) {
 	validator := v.getOrCreateValidator(staker.SubnetID, staker.NodeID)
 	if validator.delegators == nil {
 		validator.delegators = btree.NewG(defaultTreeDegree, (*Staker).Less)

--- a/vms/omegavm/state/stakers.go
+++ b/vms/omegavm/state/stakers.go
@@ -222,6 +222,9 @@ func (v *baseStakers) PutDelegator(staker *Staker) {
 	v.stakers.ReplaceOrInsert(staker)
 }
 
+// PutModifiedDelegator inserts a delegator whose staking parameters have been
+// updated in-memory into the validator's delegator set
+// and the flat staker index, without recording a diff entry.
 func (v *baseStakers) PutModifiedDelegator(staker *Staker) {
 	validator := v.getOrCreateValidator(staker.SubnetID, staker.NodeID)
 	if validator.delegators == nil {
@@ -232,6 +235,9 @@ func (v *baseStakers) PutModifiedDelegator(staker *Staker) {
 	v.stakers.ReplaceOrInsert(staker)
 }
 
+// DeleteModifiedDelegator removes a previously modified delegator from the
+// validator's delegator set and the flat staker index, pruning the validator
+// if it no longer has any stakers, without recording a diff entry.
 func (v *baseStakers) DeleteModifiedDelegator(staker *Staker) {
 	validator := v.getOrCreateValidator(staker.SubnetID, staker.NodeID)
 	if validator.delegators != nil {

--- a/vms/omegavm/state/state.go
+++ b/vms/omegavm/state/state.go
@@ -771,6 +771,10 @@ func (s *state) GetCurrentStakerIterator() (StakerIterator, error) {
 }
 
 
+// ModifyCurrentStakerIterator rewrites the current staker set after
+// Pyruni activation so that validators and delegators end times updated when iterated over, without
+// mutating the underlying persisted transactions.
+// It will only run once after Pyruni activation.
 func (s *state) ModifyCurrentStakerIterator() (StakerIterator, error) {
 	if !s.cfg.IsPyruniActivated(s.timestamp) {
 		return s.currentStakers.GetStakerIterator(), nil

--- a/vms/omegavm/state/state.go
+++ b/vms/omegavm/state/state.go
@@ -728,6 +728,19 @@ func (s *state) GetCurrentValidatorsWeight(subnetID ids.ID) (uint64, error) {
 	return s.currentStakers.GetCurrentValidatorsWeight(subnetID)
 }
 
+func (s *state) GetModifiedStakerParams(staker Staker) (*Staker, error) {
+	tx, _, err := s.GetTx(staker.TxID)
+	if err != nil {
+		return nil, err
+	}
+	modifiedStakerTx, ok := tx.Unsigned.(txs.Staker)
+	if !ok {
+		return nil, fmt.Errorf("expected txs.Staker, got %T", tx.Unsigned)
+	}
+
+	return NewCurrentStaker(staker.TxID, modifiedStakerTx, staker.PotentialReward)
+}
+
 func (s *state) PutCurrentValidator(staker *Staker) {
 	s.currentStakers.PutValidator(staker)
 }
@@ -749,6 +762,54 @@ func (s *state) DeleteCurrentDelegator(staker *Staker) {
 }
 
 func (s *state) GetCurrentStakerIterator() (StakerIterator, error) {
+	return s.currentStakers.GetStakerIterator(), nil
+}
+
+
+// Todo: Add a new method to get modified delegators and validators end time.
+func (s *state) ModifyCurrentStakerIterator() (StakerIterator, error) {
+	if !s.cfg.IsPyruniActivated(s.timestamp) {
+		return s.currentStakers.GetStakerIterator(), nil
+	}
+
+	inner := s.currentStakers.GetStakerIterator()
+
+	var updates []struct {
+		prev      *Staker
+		modified *Staker
+	}
+	for inner.Next() {
+		prev := inner.Value()
+		if prev == nil {
+			continue
+		}
+		modified, err := s.GetModifiedStakerParams(*prev)
+		if err != nil {
+			continue
+		}
+		modified.MintRate.Set(prev.MintRate)
+		modified.FeePerWeightPaid.Set(prev.FeePerWeightPaid)
+		updates = append(updates, struct {
+			prev      *Staker
+			modified *Staker
+		}{prev, modified})
+	}
+	inner.Release()
+
+	for _, u := range updates {
+		prev, modified := u.prev, u.modified
+		currentVdr, err := s.GetCurrentValidator(prev.SubnetID, prev.NodeID)
+		isValidator := err == nil && currentVdr.TxID == prev.TxID
+		if isValidator {
+			s.currentStakers.DeleteValidator(prev)
+			s.currentStakers.PutModifiedValidator(modified)
+		} else {
+			// Todo: test delete delegator
+			// s.currentStakers.DeleteDelegator(prev)
+			s.currentStakers.PutModifiedDelegator(modified)
+		}
+	}
+
 	return s.currentStakers.GetStakerIterator(), nil
 }
 
@@ -994,7 +1055,7 @@ func (s *state) GetTx(txID ids.ID) (*txs.Tx, status.Status, error) {
 		return nil, status.Unknown, err
 	}
 
-	tx, err = modifyTx(tx)
+	tx, err = s.modifyTx(tx)
 	if err != nil {
 		return nil, status.Unknown, err
 	}
@@ -1358,7 +1419,7 @@ func (s *state) syncGenesis(genesisBlk blocks.Block, genesis *genesis.State) err
 
 	// Persist primary network validator set at genesis
 	for _, vdrTx := range genesis.Validators {
-		modifiedTx, err := modifyTx(vdrTx)
+		modifiedTx, err := s.modifyTx(vdrTx)
 		if err != nil {
 			return err
 		}

--- a/vms/omegavm/state/state.go
+++ b/vms/omegavm/state/state.go
@@ -401,6 +401,8 @@ type state struct {
 	feePerWeightStored, persistedFeePerWeightStored               *big.Int
 	stakerAccumulatedMintRate, persistedStakerAccumulatedMintRate *big.Int
 	stakeSyncTimestamp, persistedStakeSyncTimestamp               time.Time
+
+	isTxModified bool
 }
 
 // heightRange is used to track which heights are safe to use the native DB
@@ -733,6 +735,9 @@ func (s *state) GetModifiedStakerParams(staker Staker) (*Staker, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	tx, _ = s.modifyTx(tx)
+
 	modifiedStakerTx, ok := tx.Unsigned.(txs.Staker)
 	if !ok {
 		return nil, fmt.Errorf("expected txs.Staker, got %T", tx.Unsigned)
@@ -762,13 +767,16 @@ func (s *state) DeleteCurrentDelegator(staker *Staker) {
 }
 
 func (s *state) GetCurrentStakerIterator() (StakerIterator, error) {
-	return s.currentStakers.GetStakerIterator(), nil
+	return s.ModifyCurrentStakerIterator()
 }
 
 
-// Todo: Add a new method to get modified delegators and validators end time.
 func (s *state) ModifyCurrentStakerIterator() (StakerIterator, error) {
 	if !s.cfg.IsPyruniActivated(s.timestamp) {
+		return s.currentStakers.GetStakerIterator(), nil
+	}
+
+	if s.isTxModified {
 		return s.currentStakers.GetStakerIterator(), nil
 	}
 
@@ -804,11 +812,12 @@ func (s *state) ModifyCurrentStakerIterator() (StakerIterator, error) {
 			s.currentStakers.DeleteValidator(prev)
 			s.currentStakers.PutModifiedValidator(modified)
 		} else {
-			// Todo: test delete delegator
-			// s.currentStakers.DeleteDelegator(prev)
+			s.currentStakers.DeleteModifiedDelegator(prev)
 			s.currentStakers.PutModifiedDelegator(modified)
 		}
 	}
+
+	s.isTxModified = true
 
 	return s.currentStakers.GetStakerIterator(), nil
 }
@@ -1051,11 +1060,6 @@ func (s *state) GetTx(txID ids.ID) (*txs.Tx, status.Status, error) {
 	}
 
 	tx, err := txs.Parse(txs.GenesisCodec, stx.Tx)
-	if err != nil {
-		return nil, status.Unknown, err
-	}
-
-	tx, err = s.modifyTx(tx)
 	if err != nil {
 		return nil, status.Unknown, err
 	}
@@ -1419,12 +1423,7 @@ func (s *state) syncGenesis(genesisBlk blocks.Block, genesis *genesis.State) err
 
 	// Persist primary network validator set at genesis
 	for _, vdrTx := range genesis.Validators {
-		modifiedTx, err := s.modifyTx(vdrTx)
-		if err != nil {
-			return err
-		}
-
-		tx, ok := modifiedTx.Unsigned.(*txs.AddValidatorTx)
+		tx, ok := vdrTx.Unsigned.(*txs.AddValidatorTx)
 		if !ok {
 			return fmt.Errorf("expected tx type *txs.AddValidatorTx but got %T", vdrTx.Unsigned)
 		}
@@ -1436,7 +1435,6 @@ func (s *state) syncGenesis(genesisBlk blocks.Block, genesis *genesis.State) err
 
 		s.PutCurrentValidator(staker)
 
-		// We add original transaction
 		s.AddTx(vdrTx, status.Committed)
 	}
 

--- a/vms/omegavm/state/tx_modifier.go
+++ b/vms/omegavm/state/tx_modifier.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"time"
+
 	"github.com/DioneProtocol/odysseygo/genesis"
 	"github.com/DioneProtocol/odysseygo/ids"
 	"github.com/DioneProtocol/odysseygo/utils/formatting/address"
@@ -14,6 +16,16 @@ var (
 
 	// Validators work for about 6 years, so we subtract this duration from
 	// each validator's end time to reduce the validation time.
+
+	// update time for delegator which has start time equal to genesis start time
+	testnetDelegatorEndTime = time.Date(2027, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	nonActiveValidatorStartTime = time.Date(2025, time.March, 1, 0, 0, 0, 0, time.UTC)
+
+	// update time for non active validator which has start time before nonActiveValidatorStartTime
+	testnetNonActiveValidatorEndTimeDecrement uint64 = 1 * 365 * 24 * 60 * 60 // 1 year in seconds
+
+	// update time for validator which has end time before testnetEndTimeDecrement
 	testnetEndTimeDecrement uint64 = 5 * 365 * 24 * 60 * 60 // 5 years in seconds
 )
 
@@ -31,30 +43,82 @@ func init() {
 //
 // Currently, there are no delegators on the testnet, so delegator end times do
 // not need to be adjusted.
-func modifyTx(tx *txs.Tx) (*txs.Tx, error) {
-	utx, ok := tx.Unsigned.(*txs.AddValidatorTx)
-	if ok {
+func (s *state) modifyTx(tx *txs.Tx) (*txs.Tx, error) {
+	// update end time when pyruni is activated
+	if !s.cfg.IsPyruniActivated(s.timestamp) {
+		return tx, nil
+	}
+
+	activationTime := s.cfg.PyruniTime.Unix()
+	switch utx := tx.Unsigned.(type) {
+	case *txs.AddValidatorTx:
 		// We are looking for testnet genesis validators. Genesis validators have a
 		// start time equal to the genesis start time.
 		if utx.StartTime().Unix() == int64(genesis.TestnetConfig.StartTime) {
+			return reduceValidatorEndTime(tx, testnetEndTimeDecrement)
+		}
+
+		if (utx.StartTime().Unix() <= nonActiveValidatorStartTime.Unix() && utx.EndTime().Unix() > activationTime) && utx.StartTime().Unix() != int64(genesis.TestnetConfig.StartTime) {
+			return reduceValidatorEndTime(tx, testnetNonActiveValidatorEndTimeDecrement)
+		}
+	case *txs.AddDelegatorTx:
+		vdrStartTime, err := s.GetStartTime(utx.NodeID(), utx.SubnetID())
+		if err != nil {
+			return tx, nil
+		}
+		if checkReductionRequiredForDelegator(vdrStartTime.Unix(), utx.StartTime().Unix(), utx.EndTime().Unix(), activationTime) {
 			txCopy := &txs.Tx{}
 			_, err := txs.Codec.Unmarshal(tx.Bytes(), txCopy)
 			if err != nil {
 				return tx, err
 			}
-
-			utx := txCopy.Unsigned.(*txs.AddValidatorTx)
-			if utx.End-testnetEndTimeDecrement > utx.Start {
-				utx.End = utx.End - testnetEndTimeDecrement
+	
+			utx := txCopy.Unsigned.(*txs.AddDelegatorTx)
+			utx.End = uint64(testnetDelegatorEndTime.Unix())
+			return txCopy, nil
+	
+		}
+	case *txs.AddPermissionlessDelegatorTx:
+		vdrStartTime, err := s.GetStartTime(utx.NodeID(), utx.SubnetID())
+		if err != nil {
+			return tx, nil
+		}
+		if checkReductionRequiredForDelegator(vdrStartTime.Unix(), utx.StartTime().Unix(), utx.EndTime().Unix(), activationTime) {
+			txCopy := &txs.Tx{}
+			_, err := txs.Codec.Unmarshal(tx.Bytes(), txCopy)
+			if err != nil {
+				return tx, err
 			}
-			utx.RewardsOwner = &secp256k1fx.OutputOwners{
-				Threshold: 1,
-				Addrs:     []ids.ShortID{rewardOwnerID},
-			}
-
+	
+			utx := txCopy.Unsigned.(*txs.AddPermissionlessDelegatorTx)
+			utx.End = uint64(testnetDelegatorEndTime.Unix())
+	
 			return txCopy, nil
 		}
 	}
 
 	return tx, nil
+}
+
+func reduceValidatorEndTime(tx *txs.Tx, endTimeDecrement uint64) (*txs.Tx, error) {
+	txCopy := &txs.Tx{}
+	_, err := txs.Codec.Unmarshal(tx.Bytes(), txCopy)
+	if err != nil {
+		return tx, err
+	}
+
+	utx := txCopy.Unsigned.(*txs.AddValidatorTx)
+	if int64(utx.End-endTimeDecrement) > int64(utx.Start) {
+		utx.End = utx.End - endTimeDecrement
+	}
+	utx.RewardsOwner = &secp256k1fx.OutputOwners{
+		Threshold: 1,
+		Addrs:     []ids.ShortID{rewardOwnerID},
+	}
+
+	return txCopy, nil
+}
+
+func checkReductionRequiredForDelegator(vdrStartTime int64, startTime int64, endTime int64, activationTime int64) bool {
+	return vdrStartTime == int64(genesis.TestnetConfig.StartTime) && (startTime < activationTime && endTime > activationTime)
 }

--- a/vms/omegavm/state/tx_modifier.go
+++ b/vms/omegavm/state/tx_modifier.go
@@ -37,12 +37,11 @@ func init() {
 	rewardOwnerID = addr
 }
 
-// modifyTx adjusts the end time and reward owner for genesis validators in
-// the transaction. It only affects the value returned by the GetTx function.
-// The state of the genesis transactions remains unchanged.
-//
-// Currently, there are no delegators on the testnet, so delegator end times do
-// not need to be adjusted.
+// modifyTx adjusts the end time and reward owner for genesis validators, 
+// non active validators and shortens delegator periods
+// that has delegation on genesis validators so they end at the configured delegator
+// cutoff time, once Pyruni is activated. 
+// It only affects the value returned by the GetCurrentStakerIterator function.
 func (s *state) modifyTx(tx *txs.Tx) (*txs.Tx, error) {
 	// update end time when pyruni is activated
 	if !s.cfg.IsPyruniActivated(s.timestamp) {

--- a/vms/omegavm/state/tx_modifier.go
+++ b/vms/omegavm/state/tx_modifier.go
@@ -120,5 +120,5 @@ func reduceValidatorEndTime(tx *txs.Tx, endTimeDecrement uint64) (*txs.Tx, error
 }
 
 func checkReductionRequiredForDelegator(vdrStartTime int64, startTime int64, endTime int64, activationTime int64) bool {
-	return vdrStartTime == int64(genesis.TestnetConfig.StartTime) && (startTime < activationTime && endTime > activationTime)
+	return vdrStartTime == int64(genesis.TestnetConfig.StartTime) && (startTime < activationTime && endTime > testnetDelegatorEndTime.Unix())
 }


### PR DESCRIPTION
- Updated the end time of delegators and non-active validators
- Implemented a hardfork activation check for modifying transaction end times
- Removed modifyTx from GetTx and syncGenesis
- Implemented modifyCurrentStakeIterator to return the updated end time of the current staker
- Added a check in modifyCurrentStakerIterator to ensure the transaction end time is updated only once and not repeatedly.